### PR TITLE
Fix for span tag in img alt for no pic

### DIFF
--- a/content-single-download.php
+++ b/content-single-download.php
@@ -20,7 +20,7 @@ do_action( 'digitalstore_before_content', $post ); ?>
                 <?php if ( has_post_thumbnail() ): ?>
                     <?php the_post_thumbnail( 'digitalstore_thumb_321x292' ); ?>
                 <?php else: ?>
-                    <img src="<?php echo get_stylesheet_directory_uri(); ?>/img/nopic-large.gif" alt="<?php the_title(); ?>"/>
+                    <img src="<?php echo get_stylesheet_directory_uri(); ?>/img/nopic-large.gif" alt="<?php echo strip_tags( get_the_title() ); ?>"/>
                 <?php endif ?>
             </div><!-- entry-image -->
             


### PR DESCRIPTION
EDD's edd_microdata_title filter wraps `the_title()` in a span, so that needs to be stripped out when using the title for img alt's etc.
