### PR TITLE
Hide ajax loading in purchase link

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,7 @@
 
 define( 'EDD_DIGITAL_STORE_STORE_URL', 'https://easydigitaldownloads.com' );
 define( 'EDD_DIGITAL_STORE_THEME_NAME', 'Digital Store Theme' );
-define( 'EDD_DIGITAL_STORE_VERSION', '1.3.6' );
+define( 'EDD_DIGITAL_STORE_VERSION', '1.3.7' );
 
 
 // Set content width

--- a/style.css
+++ b/style.css
@@ -1893,6 +1893,134 @@ input, textarea {
   line-height: 1.143em;
 }
 
+/* =Ajax Add To Cart Button
+-------------------------------------------------------------- */
+.edd_purchase_submit_wrapper {
+    position: relative;
+}
+.edd_purchase_submit_wrapper a.edd-add-to-cart {
+    text-decoration: none;
+    display: none;
+    position: relative;
+    overflow: hidden;
+}
+.edd_purchase_submit_wrapper a.edd-add-to-cart.edd-has-js {
+    display: inline-block;
+}
+.edd_purchase_submit_wrapper .edd-cart-ajax {
+    display: none;
+    position: relative;
+    left: -35px;
+}
+.edd-submit.button.edd-ajax-loading {
+    padding-right: 30px;
+}
+.edd-add-to-cart .edd-add-to-cart-label {
+    opacity: 1;
+    filter: alpha(opacity=100);
+}
+.edd-loading,
+.edd-loading:after {
+    border-radius: 50%;
+    display: block;
+    width: 1.5em;
+    height: 1.5em;
+}
+.edd-loading {
+    -webkit-animation: edd-spinning 1.1s infinite linear;
+    animation: edd-spinning 1.1s infinite linear;
+    border-top: 0.2em solid rgba(255, 255, 255, 0.2);
+    border-right: 0.2em solid rgba(255, 255, 255, 0.2);
+    border-bottom: 0.2em solid rgba(255, 255, 255, 0.2);
+    border-left: 0.2em solid #fff;
+    font-size: 0.75em;
+    position: absolute;
+    left: calc(50% - 0.75em);
+    top: calc(50% - 0.75em);
+    opacity: 0;
+    filter: alpha(opacity=0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+}
+a.edd-add-to-cart.white .edd-loading,
+.edd-discount-loader.edd-loading,
+.edd-loading-ajax.edd-loading {
+    border-top-color: rgba(0, 0, 0, 0.2);
+    border-right-color: rgba(0, 0, 0, 0.2);
+    border-bottom-color: rgba(0, 0, 0, 0.2);
+    border-left-color: #000;
+}
+.edd-loading-ajax.edd-loading {
+    display: inline-block;
+    position: relative;
+    top: 0;
+    left: 0.25em;
+    vertical-align: middle;
+}
+
+#edd_checkout_form_wrap .edd-cart-adjustment .edd-apply-discount.edd-submit {
+    display: inline-block;
+}
+.edd-discount-loader.edd-loading {
+    display: inline-block;
+    position: relative;
+    left: auto;
+    vertical-align: middle;
+    width: 1.25em;
+    height: 1.25em;
+}
+
+.edd-loading-ajax.edd-loading {
+    opacity: 1;
+}
+
+@-webkit-keyframes edd-spinning {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+@keyframes edd-spinning {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}
+a.edd-add-to-cart .edd-add-to-cart-label,
+.edd-loading {
+    -webkit-transition: .1s opacity !important;
+    -moz-transition: .1s opacity !important;
+    -ms-transition: .1s opacity !important;
+    -o-transition: .1s opacity !important;
+    transition: .1s opacity !important;
+}
+.edd-add-to-cart[data-edd-loading] .edd-add-to-cart-label {
+    opacity: 0;
+    filter: alpha(opacity=0);
+}
+.edd-add-to-cart[data-edd-loading] .edd-loading,
+.edd-discount-loader.edd-loading {
+    opacity: 1;
+    filter: alpha(opacity=100);
+}
+.edd-cart-added-alert {
+    color: #567622;
+    display: block;
+    position: absolute;
+}
+.assistive-text, .screen-reader-text {
+    position: absolute !important;
+    clip: rect(1px, 1px, 1px, 1px);
+}
+
 /* =DropDown
 -------------------------------------------------------------- */
 .dropdown-toggle {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://www.easydigitaldownloads.com/theme/digitalstore
 Description: A semantic & responsive HTML5 theme for your awesome digital store.
 Author: EDD Team
 Author URI: http://www.easydigitaldownloads.com/
-Version: 1.3.6
+Version: 1.3.7
 Github Theme URI: https://github.com/sksmatt/Digital-Store
 Tags: white, dark, light, flexible-width, custom-colors, editor-style, featured-images, threaded-comments, translation-ready
 license: GPL2


### PR DESCRIPTION
Copied Ajax add to cart button CSS from edd.css in EDD v2.7.2 and added it to style.css since Digital Store doesn't use edd.css and EDD 2.7 results in .edd-loading being visible always.

fixes #65.